### PR TITLE
Add tsfresh 0.18.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - pip
     - setuptools_scm
     - setuptools
-    - sphinx
   run:
     - python >=3.5
     - requests >=2.9.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,9 @@ source:
 
 build:
   number: 0
+  # 2021/10/6: Skip building on osx-arm64 because statsmodels>=0.9.0 isn't available on this platform yet.
+  # Skip building on aarch64 because dask + distributed version don't work well together on it yet.
+  skip: true  # [arm64 or aarch64]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,7 @@ source:
 build:
   number: 0
   # 2021/10/6: Skip building on osx-arm64 because statsmodels>=0.9.0 isn't available on this platform yet.
-  # Skip building on aarch64 because dask + distributed version don't work well together on it yet.
-  skip: true  # [arm64 or aarch64]
+  skip: true  # [arm64]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,34 +15,40 @@ build:
   number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  entry_points:
+    - run_tsfresh = tsfresh.scripts.run_tsfresh:main
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.5
     - pip
     - setuptools_scm
     - setuptools
+    - sphinx
   run:
-    - python >=3.6
-    - setuptools
+    - python >=3.5
     - requests >=2.9.1
-    - numpy >=1.12.1
-    - pandas >=0.20.3,!=0.24.*
+    - numpy >=1.15.1
+    - pandas >=0.25.0
     - scipy >=1.2.0
-    - statsmodels >=0.8.0
+    - statsmodels >=0.9.0
     - patsy >=0.4.1
-    - scikit-learn >=0.19.0
+    - scikit-learn >=0.22.0
     - tqdm >=4.10.0
-    - dask >=0.15.2
-    - distributed >=1.18.3
+    - dask >=2.9.0
+    - distributed >=2.11.0
     - matrixprofile >=1.1.10,<2.0.0
     - stumpy >=1.7.2
 
 test:
-  requires:
-    - pip
-  commands:
-    - pip check
+  # 2021/10/06: pip check causes an error "matrixprofile 1.1.10 has requirement protobuf==3.11.2, but you have protobuf 3.17.2."
+  # but the upstream https://github.com/matrix-profile-foundation/matrixprofile/blob/v1.1.10/requirements.txt
+  # uses protobuf>=3.11.2,<4.0.0, so pip check was disable.
+  # Enable it when matrixprofile will be >= 1.1.11.
+  #requires:
+  #  - pip
+  #commands:
+  #  - pip check
   imports:
     - tsfresh
 


### PR DESCRIPTION
Popularity:  49641 downloads -  tsfresh  0.18.0  Automatic extraction of relevant features from time series
  license: MIT
Release date:  Mar 6, 2021
Bug Tracker: new open issues https://github.com/blue-yonder/tsfresh/issues
Github releases:  https://github.com/blue-yonder/tsfresh/releases
Upstream Changelog: https://github.com/blue-yonder/tsfresh/blob/main/CHANGES.rst
Upstream license file: https://github.com/blue-yonder/tsfresh/blob/v0.18.0/LICENSE.txt
Requirements from conda-forge: https://github.com/conda-forge/tsfresh-feedstock/blob/master/recipe/meta.yaml
Upstream requirements: https://github.com/blue-yonder/tsfresh/blob/v0.18.0/requirements.txt
Upstream setup file: https://github.com/blue-yonder/tsfresh/blob/v0.18.0/setup.py
Upstream setup.cfg: https://github.com/blue-yonder/tsfresh/blob/v0.18.0/setup.cfg

Actions:
1. Add entry_points
2. Update dependencies
3. Disable pip check

Result:
- all-succeeded on concourse
